### PR TITLE
Adds wasm32 support (using wasm-bindgen)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 derive_builder = "0.9.0"
 fancy-regex = "0.3.0"
-itertools = "0.8.0"
+itertools = "0.9.0"
 lazy_static = "1.3"
 quick-error = "1.2"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ derive_builder = "0.9.0"
 fancy-regex = "0.3.0"
 itertools = "0.9.0"
 lazy_static = "1.3"
-quick-error = "1.2"
+quick-error = "2.0"
 regex = "1"
 chrono = "0.4.7"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ quick_error! {
     pub enum ZxcvbnError {
         /// Indicates that a blank password was passed in to `zxcvbn`
         BlankPassword {
-            description("Zxcvbn cannot evaluate a blank password")
+            display("Zxcvbn cannot evaluate a blank password")
         }
     }
 }


### PR DESCRIPTION
We've added wasm32 support by eliminating the std::time::Instant usage and adding the `wasmbind` chrono feature since it was already a dependency.

Instead of using usize types in scoring which failed the overflow test on wasm32 we switched to consistently using u64 types. Wasm-bindgen allows for u64 types by translating to the BigInt type in JS.

All integration tests are passing when running `wasm-pack test --node` 